### PR TITLE
Fix Issue #11

### DIFF
--- a/Bloxstrap/App.xaml.cs
+++ b/Bloxstrap/App.xaml.cs
@@ -313,9 +313,10 @@ namespace Bloxstrap
 
             if (uninstallKey?.GetValue("InstallLocation") is string installLocValue)
             {
+                installLocValue = Environment.ExpandEnvironmentVariables(installLocValue);
                 if (Directory.Exists(installLocValue))
                 {
-                    installLocation = installLocValue;
+                    installLocation = Environment.ExpandEnvironmentVariables(installLocValue);
                 }
                 else
                 {

--- a/Bloxstrap/Paths.cs
+++ b/Bloxstrap/Paths.cs
@@ -39,7 +39,11 @@
 
         public static void Initialize(string baseDirectory)
         {
-            Base = baseDirectory;
+            Base = Environment.ExpandEnvironmentVariables(baseDirectory);
+            if (!System.IO.Directory.Exists(Base))
+            {
+                System.IO.Directory.CreateDirectory(Base);
+            }
             Downloads = Path.Combine(Base, "Downloads");
             SavedFlagProfiles = Path.Combine(Base, "SavedFlagProfiles");
             Logs = Path.Combine(Base, "Logs");


### PR DESCRIPTION
I'm not sure whether this actually fixes the issue, but the attached logs seem to indicate an unexpanded `%UserProfile%`, which I fixed by using `Environment.ExpandEnvironmentVariables`.
```
2026-03-01T22:00:42Z [App::OnStartup] Starting Froststrap v1.5.0
2026-03-01T22:00:42Z [App::OnStartup] Compiled Monday, 23 February 2026 at 11:19:16 AM from commit 8c346c006e0053807f7c3bd60fd01d5a173b103c (tag/v1.5.0)
2026-03-01T22:00:42Z [App::OnStartup] OSVersion: Microsoft Windows NT 10.0.26200.0
2026-03-01T22:00:42Z [App::OnStartup] Loaded from %UserProfile%\AppData\Local\Froststrap\Froststrap.exe
2026-03-01T22:00:42Z [App::OnStartup] Temp path is %UserProfile%\AppData\Local\Temp\Froststrap
2026-03-01T22:00:42Z [App::OnStartup] WindowsStartMenu path is %UserProfile%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs
2026-03-01T22:00:42Z [Logger::Initialize] Initializing at %UserProfile%\AppData\Local\Froststrap\Logs\Froststrap_20260301T220042Z.log
2026-03-01T22:00:42Z [App::GlobalExceptionHandler] An exception occurred
2026-03-01T22:00:42Z [App::FinalizeExceptionHandling] (0x80070002) System.IO.FileNotFoundException: Could not find file '%UserProfile%\AppData\Local\Froststrap\Logs'.
File name: '%UserProfile%\AppData\Local\Froststrap\Logs'
   at System.IO.FileSystem.CreateDirectory(String fullPath, Byte[] securityDescriptor)
   at System.IO.Directory.CreateDirectory(String path)
   at Bloxstrap.Logger.Initialize(Boolean useTempDir)
   at Bloxstrap.App.OnStartup(StartupEventArgs e)
   at System.Windows.Application.<.ctor>b__1_0(Object unused)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   ```
   
   ##### This PR is only for Issue #11.