### PR TITLE
Clean up unused using directives in App.xaml.cs

### DIFF
--- a/Bloxstrap/App.xaml.cs
+++ b/Bloxstrap/App.xaml.cs
@@ -3,13 +3,10 @@ using Microsoft.Win32;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Windows;
-using System.Windows.Interop;
-using System.Windows.Media;
 using System.Windows.Shell;
 using System.Windows.Threading;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
-using Wpf.Ui.Hardware;
 
 namespace Bloxstrap
 {


### PR DESCRIPTION
Removed unused using directives for System.Windows.Interop, System.Windows.Media, and Wpf.Ui.Hardware.