### PR TITLE
Clean up unused using directives in ModGenerator.cs

### DIFF
--- a/Bloxstrap/Integrations/ModGenerator.cs
+++ b/Bloxstrap/Integrations/ModGenerator.cs
@@ -8,13 +8,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO.Compression;
 using System.Net.Http.Json;
 using System.Reflection;
-using System.Text.Json;
 
 namespace Bloxstrap.Integrations;
 


### PR DESCRIPTION
Removed unused 'using' directives for System.Diagnostics and System.Text.Json.