### PR TITLE
Remove unused System.Web namespace

### DIFF
--- a/Bloxstrap/Integrations/AccountManager.cs
+++ b/Bloxstrap/Integrations/AccountManager.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json.Linq;
 using PuppeteerExtraSharp;
 using PuppeteerExtraSharp.Plugins.ExtraStealth;
 using PuppeteerSharp;
-using System.Web;
 using System.Windows;
 using Bloxstrap.UI.Elements.Dialogs;
 


### PR DESCRIPTION
Removed unused System.Web namespace from AccountManager.cs