### PR TITLE
Fix link in FroststrapRichPresence.cs when click github button it will redirect to right repo

### DIFF
--- a/Froststrap/Integrations/FroststrapRichPresence.cs
+++ b/Froststrap/Integrations/FroststrapRichPresence.cs
@@ -114,7 +114,7 @@ namespace Froststrap.Integrations
                     },
                     Buttons =
                     [
-                        new Button { Label = "GitHub", Url = "https://github.com/RealMeddsam/Froststrap" },
+                        new Button { Label = "GitHub", Url = "https://github.com/Froststrap/Froststrap" },
                         new Button { Label = "Discord", Url = "https://discord.gg/KdR9vpRcUN" }
                     ]
                 };


### PR DESCRIPTION
This PR fixed the Froststrap RPC GitHub button to redirect you to this repo (before fix is RealMeddsam/Froststrap). Nothing special :)