### PR TITLE
Delay 500ms before searching for log files

### DIFF
--- a/Froststrap/Bootstrapper.cs
+++ b/Froststrap/Bootstrapper.cs
@@ -1874,6 +1874,8 @@ namespace Froststrap
             {
                 string rbxLogDir = Paths.RobloxLogs;
 
+                await Task.Delay(500, _cancelTokenSource.Token);
+
                 for (int i = 0; i < 60; i++)
                 {
                     if (Directory.Exists(rbxLogDir))


### PR DESCRIPTION
> I don't think it's a good idea to proceed without a delay before searching through the logs here.
> It appears that if Roblox hasn't been launched within the last 5 minutes, the first attempt to find a log file fails, triggering a 500ms delay before retrying. By then, Roblox has already created the log file, so no issues occur.
> However, if Roblox was launched within the last 5 minutes, an old log file might be detected before the new one is created. This results in the wrong log file being passed to the watcher, causing either the application to immediately show that it joined a server upon launch, or the watcher to start but remain non-functional.
> [I don’t think it has anything to do with multi-instance launching... because you can do it in any way, like... joining an old server from the history?]