### PR TITLE
fix: disable grass fflag

### DIFF
--- a/Bloxstrap/UI/ViewModels/Settings/FastFlagsViewModel.cs
+++ b/Bloxstrap/UI/ViewModels/Settings/FastFlagsViewModel.cs
@@ -17,16 +17,19 @@ namespace Bloxstrap.UI.ViewModels.Settings
         private void OpenFastFlagEditor() => OpenFlagEditorEvent?.Invoke(this, EventArgs.Empty);
 
         public ICommand OpenFastFlagEditorCommand => new RelayCommand(OpenFastFlagEditor);
-
         public bool RemoveGrass
         {
-            get => App.FastFlags?.GetPreset("Rendering.RemoveGrass1") == "0";
+            get =>
+            _flagsService.GetPreset("Rendering.RemoveGrass1") == "0" &&
+            _flagsService.GetPreset("Rendering.RemoveGrass2") == "0" &&
+            _flagsService.GetPreset("Rendering.RemoveGrass3") == "0";
             set
             {
-                App.FastFlags.SetPreset("Rendering.RemoveGrass1", value ? "0" : null);
-                App.FastFlags.SetPreset("Rendering.RemoveGrass2", value ? "0" : null);
-                App.FastFlags.SetPreset("Rendering.RemoveGrass3", value ? "0" : null);
-            }
+                _flagsService.SetPreset("Rendering.RemoveGrass1", value ? "0" : null);
+                _flagsService.SetPreset("Rendering.RemoveGrass2", value ? "0" : null);
+                _flagsService.SetPreset("Rendering.RemoveGrass3", value ? "0" : null);
+                OnPropertyChanged();
+                }
         }
 
         public bool LowPolyMeshesEnabled


### PR DESCRIPTION
"If in fastflags editor, you add FIntFRMMaxGrassDistance or FIntFRMMinGrassDistance the "Disable Grass" GUI in fastflags presets would toggle on, even if MaxGrassDistance is set to a value above than 0.

It doesn't affect the grass distance value in the editor neither in-game but I though It could help."

Thanks to so630nic2.0 for reporting this!

The script certainly toggles on the disable grass GUI, if it detects FIntFRMMaxGrassDistance, FIntFRMMinGrassDistance in the fastflag editor or the file itself, whatever is set the value.